### PR TITLE
logic for pushing recurring tasks

### DIFF
--- a/app/components/Admin.js
+++ b/app/components/Admin.js
@@ -48,11 +48,11 @@ class Admin extends Component {
 
 	render() {
 
-			const dailyTodos = this.state.tasks.filter(item => item.active === true && item.recurFrequency === 'day');
-	    const weeklyTodos = this.state.tasks.filter(item => item.active === true && item.recurFrequency === 'week');
-	    const monthlyTodos = this.state.tasks.filter(item => item.active === true && item.recurFrequency === 'month');
-	    const scheduledTodos = this.state.tasks.filter(item => item.active === true && item.recurAny === false);
-	    const completedTodos = this.state.tasks.filter(item => item.active === false);
+			const dailyTodos = this.state.tasks.filter(item => item.recurFrequency === 'day');
+	    const weeklyTodos = this.state.tasks.filter(item => item.recurFrequency === 'week');
+	    const monthlyTodos = this.state.tasks.filter(item => item.recurFrequency === 'month');
+	    const scheduledTodos = this.state.tasks.filter(item => moment(item.taskDate).isAfter(moment(), 'day') === true);
+	    const completedTodos = this.state.tasks.filter(item => item.taskDate === null && item.active === false);
 
 	    return (
 	    <div>

--- a/app/components/Todohome.js
+++ b/app/components/Todohome.js
@@ -3,6 +3,7 @@ import TodoItem from "./sub/TodoItem";
 import Schedule from "./sub/Schedule";
 import TodoPanel from "./sub/TodoPanel";
 import API from "../utils/api";
+import moment from 'moment';
 
 class Home extends Component {
   constructor() {
@@ -28,13 +29,25 @@ class Home extends Component {
   getTasks() {
     //build axios methods
     API.getTasks().then((res) => {
-      console.log("get Tasks: ", res.data);
+      //activate task if date is today, 
+      //created at is in the past. 
+      //Avoid activating recurring tasks by how? Complete button should shift task date ahead by one is how.
+      //COmplete button should set item.taskdate to NULL for non-recurring, also.  
+      res.data.forEach( item => {
+                //returns true if today                       //returns true if created in past. 
+        if( item.active === false && moment(item.taskDate).isSame(moment(), 'day') ) {
+          item.active = true;
+          //&& moment(item.taskCreated).isBefore(item.taskDate, 'day')
+        }
+        //Panel will take active & today tasks only. 
+      });
+      console.log("get Tasks after activated: ", res.data);
       this.setState({ tasks: res.data });
     });
   }
 
   getSchedule() {
-
+    //INCOMPLETE
     API.getTasksType(
         { nextDate: { $exists: true } }
       ).then((res) => {

--- a/app/components/sub/AdminPanel.js
+++ b/app/components/sub/AdminPanel.js
@@ -10,13 +10,14 @@ class AdminPanel extends Component {
 
     return todos.map(item => (
       <div key={item._id} style={styles.lineHeight}>
-        <listItem>{item.text} - Scheduled: {moment(item.taskDate).format('MMMM Do YYYY')}&nbsp;&nbsp;
-          <button className="btn btn-xs btn-primary pull-right"
-            onClick={() => this.props.editTask(item)}>EDIT</button>
-            &nbsp;&nbsp;
+        <listItem>{item.text} - Scheduled: {item.taskDate ? moment(item.taskDate).format('MMMM Do YYYY') : moment(item.taskCreated).format('MMMM Do YYYY')}&nbsp;&nbsp;
           <button className="btn btn-xs btn-danger pull-right"
             onClick={() => this.props.deleteTodos(item._id)}
             >X</button>
+            {" "}
+          <button className="btn btn-xs btn-primary pull-right"
+            onClick={() => this.props.editTask(item)}>EDIT</button>
+            &nbsp;&nbsp;
         </listItem>
         <hr/>
       </div>

--- a/app/components/sub/TodoPanel.js
+++ b/app/components/sub/TodoPanel.js
@@ -7,13 +7,14 @@ class TodoPanel extends Component {
   renderTodos() {
     // Getting a filtered array of items. Boild tasks down to todos. 
     //&& moment().diff(item.taskDate, 'days') !== 0
+
     const activeTodos = this.props.tasks.filter(item => {
-      if (item.active === true && moment(item.taskDate).isSame(moment(), 'day')) {
+      if (item.active === true) {
         return true;
       }
     });
 
-    console.log(activeTodos);
+    console.log("active todos", activeTodos);
     //this.setState({ todos: activeTodos });
     return activeTodos.map(task => (
         <TodoItem 

--- a/app/utils/api.js
+++ b/app/utils/api.js
@@ -27,10 +27,16 @@ const API = {
 
   taskComplete: function(task) {
     task.active = false;  
-    //works for d/w/m, but NOT bi-daily. 
+    //works for d/w/m, bi-daily, etc. 
     if (task.recurAny === true) {
-      task.taskDate = moment(task.taskDate).clone().add(task.recurBetween, task.recurFrequency).format();
-      task.nextDate = moment(task.taskDate).clone().add(task.recurBetween, task.recurFrequency).format();
+      console.log(task.recurBetween);
+      const recurBet = task.recurBetween === null ? 1 : task.recurBetween;  
+
+      task.taskDate = moment(task.taskDate).clone().add(recurBet, task.recurFrequency).format();
+      task.nextDate = moment(task.taskDate).clone().add(recurBet, task.recurFrequency).format();
+    } else {
+      //Will this work? 
+      task.taskDate = null;
     }
 
     console.log("After complete:", task);
@@ -39,8 +45,8 @@ const API = {
       const { _id, active, taskDate, nextDate } = task;
       return axios.patch(`/api/tasks/${_id}`, {active, taskDate, nextDate});
     } else {
-      const { _id, active } = task;
-      return axios.patch(`/api/tasks/${_id}`, { active });
+      const { _id, active, taskDate } = task;
+      return axios.patch(`/api/tasks/${_id}`, { active, taskDate });
     }
 
   },


### PR DESCRIPTION
TodoItem/Completed tasks/API logic: 
-Items check if recurring, if not, taskDate will become null and itemCreated at will display in Admin. 
-Items check if recurBetween exists, if not 1 day between events to be pushed.
-Task date assumes next date, next date pushes back. 

TodoHome activator logic:
-Items marked false and taskDate is today are marked 'true' for items scheduled "in the future"
-Effectively activating tasks

Todo panel logic: 
-Any active tasks will fill onto board. 

Admin panel logic:
-Any active/inactive tasks will display and be sorted into panels. 

Todo item logic:
-Completed tasks are pushed to API to change taskDate/nextDate, will not activate tasks without taskDate === today as a result. 